### PR TITLE
Initialize backend scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk-…

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,21 @@
+name: Python CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint import errors
+        run: python -m compileall -q .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Mental-Health Chat Backend
+
+A simple FastAPI backend for the Mental-Health Typebot project.
+
+## Quick start
+
+```bash
+# clone and enter the repo
+$ git clone <this repo url>
+$ cd mhtp-chat-backend
+
+# create and activate a virtual environment
+$ python -m venv .venv
+$ source .venv/bin/activate
+
+# install dependencies
+$ pip install -r requirements.txt
+
+# run the API server
+$ uvicorn backend.app.main:app --reload
+```
+
+For convenience on Unix systems you can also run `scripts/run_local.sh` which
+loads variables from `.env` before starting Uvicorn.
+
+## Folder overview
+
+- `backend/` – FastAPI application code
+- `scripts/` – helper scripts for local development
+- `docs/` – project documentation
+- `.github/workflows/` – CI configuration
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="MHTP Chat Backend")
+
+@app.get("/ping")
+async def ping():
+    return {"status": "ok"}
+
+class MessageIn(BaseModel):
+    session_id: str
+    role: str  # "user" | "assistant"
+    content: str
+
+@app.post("/chat")
+async def chat(msg: MessageIn):
+    """Placeholder – will later call OpenAI Assistants API.
+    For now, just echoes back."""
+    if msg.role != "user":
+        raise HTTPException(status_code=400, detail="role must be 'user'")
+    return {"reply": f"echo: {msg.content}"}
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+```mermaid
+graph TD
+  A[Typebot] -->|POST /chat| B(FastAPI backend)
+  B --> C(OpenAI Assistants API)
+  B <--> D[(Vector DB / storage)]
+```
+
+- **Typebot**: frontend chatbot that sends user messages.
+- **FastAPI backend**: receives chat requests and orchestrates responses.
+- **OpenAI Assistants API**: TODO – integrate for generating replies.
+- **Vector DB / storage**: TODO – persist conversation context or embeddings.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.1
+python-dotenv==1.0.1
+openai==1.30.5

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export $(grep -v '^#' .env | xargs)   # carga variables locales
+uvicorn backend.app.main:app --reload


### PR DESCRIPTION
## Summary
- scaffold initial FastAPI backend and docs
- provide requirements and local run script
- add sample env file and GitHub Actions workflow

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_685e6bbc6bdc8325abb9b365acf2d0eb